### PR TITLE
Change API from initializer based injection to environment

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/AdvancedMap.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AdvancedMap.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AdvancedMap"
+               BuildableName = "AdvancedMap"
+               BlueprintName = "AdvancedMap"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AdvancedMapTests"
+               BuildableName = "AdvancedMapTests"
+               BlueprintName = "AdvancedMapTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AdvancedMap"
+            BuildableName = "AdvancedMap"
+            BlueprintName = "AdvancedMap"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A66EA5FD298D52A300F9E5F9 /* READMESampleMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66EA5FC298D52A300F9E5F9 /* READMESampleMap.swift */; };
 		A6982BBC297C822200F792BE /* ConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6982BBB297C822200F792BE /* ConfigurationView.swift */; };
 		A6E5DD4B29524A100017FDB9 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E5DD4A29524A100017FDB9 /* ExampleApp.swift */; };
 		A6E5DD4D29524A100017FDB9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E5DD4C29524A100017FDB9 /* ContentView.swift */; };
@@ -16,6 +17,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		A66EA5FC298D52A300F9E5F9 /* READMESampleMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = READMESampleMap.swift; sourceTree = "<group>"; };
 		A6982BBB297C822200F792BE /* ConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationView.swift; sourceTree = "<group>"; };
 		A6E5DD4729524A100017FDB9 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6E5DD4A29524A100017FDB9 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
@@ -61,6 +63,7 @@
 			isa = PBXGroup;
 			children = (
 				A6E6C8EB29524B28001DD9FD /* Info.plist */,
+				A66EA5FC298D52A300F9E5F9 /* READMESampleMap.swift */,
 				A6E5DD4A29524A100017FDB9 /* ExampleApp.swift */,
 				A6E5DD4C29524A100017FDB9 /* ContentView.swift */,
 				A6E5DD4E29524A110017FDB9 /* Assets.xcassets */,
@@ -161,6 +164,7 @@
 			files = (
 				A6E5DD4D29524A100017FDB9 /* ContentView.swift in Sources */,
 				A6982BBC297C822200F792BE /* ConfigurationView.swift in Sources */,
+				A66EA5FD298D52A300F9E5F9 /* READMESampleMap.swift in Sources */,
 				A6E5DD4B29524A100017FDB9 /* ExampleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Example/ConfigurationView.swift
+++ b/Example/Example/ConfigurationView.swift
@@ -23,7 +23,8 @@ struct ConfigurationView: View {
   var body: some View {
     NavigationStack {
       ZStack {
-        AdvancedMap(configuration: configuration, mapRect: $region)
+        AdvancedMap(mapRect: $region)
+          .mapConfiguration(configuration)
           .ignoresSafeArea()
           .onAppear {
             CLLocationManager().requestWhenInUseAuthorization()

--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -58,7 +58,12 @@ struct ContentView: View {
   var body: some View {
     NavigationStack {
       ZStack {
-        map
+        AdvancedMap(mapRect: $region)
+          .mapConfiguration(configuration)
+          .annotations(annotations, annotationViewFactory: annotationViewFacotry())
+          .overlays(overlays, overlayRendererFactory: overlayRendererFactory())
+          .onLongPressMapGesture(tapOrClickHandler)
+          .annotationDragHandler(annotationDragHandler)
           .ignoresSafeArea()
           .onAppear {
             CLLocationManager().requestWhenInUseAuthorization()
@@ -122,73 +127,6 @@ struct ContentView: View {
       annotations[index].coordinate = location
       updateOverlays()
     }
-}
-
-// MARK: - Platform Specific Map Initialization
-
-extension ContentView {
-  var map: some View {
-#if os(iOS)
-    AdvancedMap(
-      configuration: configuration,
-      mapRect: $region,
-      userTrackingMode: $userTrackingMode,
-      showsUserLocation: true,
-      isZoomEnabled: true,
-      isScrollEnabled: true,
-      isRotateEnabled: true,
-      isPitchEnabled: true,
-      showsCompass: true,
-      showsScale: true,
-      annotations: annotations,
-      annotationViewFactory: annotationViewFacotry(),
-      overlays: overlays,
-      overlayRendererFactory: overlayRendererFactory(),
-//      tapOrClickHandler: tapOrClickHandler,
-      longPressHandler: tapOrClickHandler,
-      annotationDragHandler: annotationDragHandler
-    )
-#elseif os(macOS)
-    AdvancedMap(
-      configuration: configuration,
-      mapRect: $region,
-      userTrackingMode: $userTrackingMode,
-      showsUserLocation: true,
-      isZoomEnabled: true,
-      isScrollEnabled: true,
-      isRotateEnabled: true,
-      isPitchEnabled: true,
-      showsPitchControl: true,
-      showsZoomControls: true,
-      showsCompass: true,
-      showsScale: true,
-      annotations: annotations,
-      annotationViewFactory: annotationViewFacotry(),
-      overlays: overlays,
-      overlayRendererFactory: overlayRendererFactory(),
-      tapOrClickHandler: tapOrClickHandler,
-      longPressHandler: tapOrClickHandler,
-      annotationDragHandler: annotationDragHandler
-    )
-#elseif os(tvOS)
-    AdvancedMap(
-      configuration: configuration,
-      mapRect: $region,
-      showsUserLocation: true,
-      isZoomEnabled: true,
-      isScrollEnabled: true,
-      isRotateEnabled: true,
-      isPitchEnabled: true,
-      showsPitchControl: true,
-      showsZoomControls: true,
-      showsCompass: true,
-      annotations: annotations,
-      annotationViewFactory: annotationViewFacotry(),
-      overlays: overlays,
-      overlayRendererFactory: overlayRendererFactory()
-    )
-#endif
-  }
 }
 
 // MARK: - Previews

--- a/Example/Example/READMESampleMap.swift
+++ b/Example/Example/READMESampleMap.swift
@@ -1,0 +1,45 @@
+import AdvancedMap
+import MapKit
+import SwiftUI
+
+struct TappableMapWithAnnotations: View {
+
+  static let annotationViewFactory = AnnotationViewFactory(
+    register: { mapView in
+      mapView.register(MKMarkerAnnotationView.self, forAnnotationViewWithReuseIdentifier: String(describing: MKPointAnnotation.self))
+    },
+    view: { mapView, annotation in
+      mapView.dequeueReusableAnnotationView(withIdentifier: String(describing: MKPointAnnotation.self), for: annotation)
+    }
+  )
+
+  @State var rect: MKMapRect? = nil
+  @State var annotations: [MKPointAnnotation] = [MKPointAnnotation]()
+
+  var body: some View {
+    AdvancedMap(mapRect: $rect)
+      .annotations(annotations, annotationViewFactory: Self.annotationViewFactory)
+      .onTapOrClickMapGesture { coordinate in
+        let annotation = MKPointAnnotation()
+        annotation.coordinate = coordinate
+        annotations.append(annotation)
+      }
+  }
+}
+
+struct TappableMap: View {
+  var body: some View {
+    // Uses MKMapView's behavior of starting the map over the
+    // phone's current country. Still scrollable by default.
+    AdvancedMap(mapRect: .constant(nil))
+      .onTapOrClickMapGesture { coordinate in
+        print("Tapped map at: \(coordinate)")
+      }
+  }
+}
+
+struct READMESampleMap_Previews: PreviewProvider {
+  static var previews: some View {
+    TappableMap()
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,10 @@ let package = Package(
   name: "SwiftUIAdvancedMap",
   platforms: [.iOS(.v16), .macOS(.v13), .tvOS(.v14)],
   products: [
-
     .library(
       name: "AdvancedMap",
-      targets: ["AdvancedMap"]),
+      targets: ["AdvancedMap"]
+    ),
   ],
   dependencies: [],
   targets: [

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ A wrapper around MKMapView with more functionality than Map.
 
 ```swift
 struct TappableMap: View {
-  
-  @State var rect: MKMapRect? = nil
-
   var body: some View {
-    AdvancedMap(mapRect: $rect) { coordinate in
-      print("Tapped on map at: \(coordinate)")
-    }
+    // `.constant(nil)` uses MKMapView's behavior of starting the map over the phone's current country. 
+    // Still scrollable by default.
+    AdvancedMap(mapRect: .constant(nil))
+      .onTapOrClickMapGesture { coordinate in
+        print("Tapped map at: \(coordinate)")
+      }
   }
 }
 ```
@@ -39,29 +39,27 @@ struct TappableMap: View {
 
 ```swift
 struct TappableMap: View {
-  
+
   static let annotationViewFactory = AnnotationViewFactory(
     register: { mapView in
       mapView.register(MKMarkerAnnotationView.self, forAnnotationViewWithReuseIdentifier: String(describing: MKPointAnnotation.self))
-    }, 
+    },
     view: { mapView, annotation in
       mapView.dequeueReusableAnnotationView(withIdentifier: String(describing: MKPointAnnotation.self), for: annotation)
     }
   )
-  
+
   @State var rect: MKMapRect? = nil
   @State var annotations: [MKPointAnnotation] = [MKPointAnnotation]()
 
   var body: some View {
-    AdvancedMap(
-      mapRect: $rect,
-      annotations: annotations,
-      annotationViewFactory: TappableMap.annotationViewFactory
-    ) { coordinate in
-      let annotation = MKPointAnnotation()
-      annotation.coordinate = coordinate
-      annotations.append(annotation)
-    }
+    AdvancedMap(mapRect: $rect)
+      .annotations(annotations, annotationViewFactory: Self.annotationViewFactory)
+      .onTapOrClickMapGesture { coordinate in
+        let annotation = MKPointAnnotation()
+        annotation.coordinate = coordinate
+        annotations.append(annotation)
+      }
   }
 }
 ```

--- a/Sources/AdvancedMap/AdvancedMap+ViewRepresentable.swift
+++ b/Sources/AdvancedMap/AdvancedMap+ViewRepresentable.swift
@@ -28,8 +28,7 @@ extension AdvancedMap: XViewRepresentable {
       context.coordinator.addLongTapOrClickGestureRecognizer(mapView: newMapView)
     }
 
-    annotationViewFactory.register(in: newMapView)
-
+    annotationViewFactory?.register(in: newMapView)
     return newMapView
   }
 
@@ -52,10 +51,13 @@ extension AdvancedMap: XViewRepresentable {
   }
 
   func update(_ mapView: MKMapView, context: Context) {
-    if let visibleMapRect, !context.coordinator.isChangingRegion, mapView.visibleMapRect != visibleMapRect, userTrackingMode == .none {
+    if let visibleMapRect,
+        !context.coordinator.isChangingRegion,
+        mapView.visibleMapRect != visibleMapRect,
+        userTrackingMode == .none {
       mapView.setVisibleMapRect(visibleMapRect, edgePadding: edgeInsets, animated: context.shouldAnimateChanges)
     }
-    switch configuration {
+    switch mapConfiguration {
     case let .standard(emphasisStyle, elevationStyle, pointOfInterestFilter, showsTraffic):
       let style = MKStandardMapConfiguration(elevationStyle: elevationStyle, emphasisStyle: emphasisStyle)
       style.pointOfInterestFilter = pointOfInterestFilter
@@ -80,7 +82,7 @@ extension AdvancedMap: XViewRepresentable {
 
     // iOS or macOS
     #if os(iOS) || os(macOS)
-    mapView.isRotateEnabled = isRotateEnabled
+    mapView.isRotateEnabled = isRotationEnabled
     mapView.isPitchEnabled = isPitchEnabled
     mapView.showsCompass = showsCompass
     if mapView.userTrackingMode != userTrackingMode {

--- a/Sources/AdvancedMap/AdvancedMap.swift
+++ b/Sources/AdvancedMap/AdvancedMap.swift
@@ -16,282 +16,41 @@ public struct AdvancedMap {
   #endif
   public typealias RegionChangingHandler = (_ changing: Bool, _ animated: Bool) -> Void
 
-  let configuration: Configuration?
+  @Environment(\.mapConfiguration) var mapConfiguration
+
   @Binding public var visibleMapRect: MKMapRect?
   #if os(iOS) || os(macOS)
   @Binding public var userTrackingMode: MKUserTrackingMode
   #endif
-  let edgeInsets: XEdgeInsets
-  let showsUserLocation: Bool
-  let isZoomEnabled: Bool
-  let isScrollEnabled: Bool
-  let isRotateEnabled: Bool
-  let isPitchEnabled: Bool
+
+  public init(
+    mapRect: Binding<MKMapRect?>,
+    userTrackingMode: Binding<MKUserTrackingMode> = .constant(MKUserTrackingMode.none)
+  ) {
+    self._visibleMapRect = mapRect
+    self._userTrackingMode = userTrackingMode
+  }
+
+  @Environment(\.edgeInsets) var edgeInsets
+  @Environment(\.showsUserLocation) var showsUserLocation
+  @Environment(\.isZoomEnabled) var isZoomEnabled
+  @Environment(\.isScrollEnabled) var isScrollEnabled
+  @Environment(\.isRotationEnabled) var isRotationEnabled
+  @Environment(\.isPitchEnabled) var isPitchEnabled
   #if os(macOS)
-  let showsPitchControl: Bool
-  let showsZoomControls: Bool
+  @Environment(\.showsPitchControl) var showsPitchControl
+  @Environment(\.showsZoomControls) var showsZoomControls
   #endif
-  let showsCompass: Bool
-  let showsScale: Bool
-  let annotations: [MKAnnotation]
-  let annotationViewFactory: AnnotationViewFactory
-  let overlays: [MKOverlay]
-  let overlayRendererFactory: OverlayRendererFactory
-  let tapOrClickHandler: DidTapOrClickMapHandler?
-  let longPressHandler: LongPressMapHandler?
-
+  @Environment(\.showsCompass) var showsCompass
+  @Environment(\.showsScale) var showsScale
+  @Environment(\.mapAnnotations) var annotations
+  @Environment(\.annotationViewFactory) var annotationViewFactory
+  @Environment(\.mapOverlays) var overlays
+  @Environment(\.overlayRendererFactory) var overlayRendererFactory
+  @Environment(\.onTapOrClickGesture) var tapOrClickHandler
+  @Environment(\.onLongPressMapGesture) var longPressHandler
   #if os(iOS) || os(macOS)
-  var annotationDragHandler: AnnotationDragHandler
+  @Environment(\.onAnnotationDragGesture) var annotationDragHandler
   #endif
-  var regionChangingHandler: RegionChangingHandler
-}
-
-// MARK: - Initializers
-
-extension AdvancedMap {
-#if os(iOS)
-  public init(
-    configuration: Configuration? = nil,
-    mapRect: Binding<MKMapRect?>,
-    userTrackingMode: Binding<MKUserTrackingMode> = .constant(MKUserTrackingMode.none),
-    edgeInsets: XEdgeInsets = .init(),
-    showsUserLocation: Bool = false,
-    isZoomEnabled: Bool = true,
-    isScrollEnabled: Bool = true,
-    isRotateEnabled: Bool = true,
-    isPitchEnabled: Bool = true,
-    showsCompass: Bool = false,
-    showsScale: Bool = false,
-    annotations: [MKAnnotation] = [],
-    annotationViewFactory: AnnotationViewFactory = .empty,
-    overlays: [MKOverlay] = [],
-    overlayRendererFactory: OverlayRendererFactory = .empty,
-    annotationDragHandler: @escaping AnnotationDragHandler = { _, _, _, _ in },
-    regionChangingHandler: @escaping RegionChangingHandler = { _, _ in }
-  ) {
-    self.configuration = configuration
-    self._visibleMapRect = mapRect
-    self._userTrackingMode = userTrackingMode
-    self.edgeInsets = edgeInsets
-    self.showsUserLocation = showsUserLocation
-    self.isZoomEnabled = isZoomEnabled
-    self.isScrollEnabled = isScrollEnabled
-    self.isRotateEnabled = isRotateEnabled
-    self.isPitchEnabled = isPitchEnabled
-    self.showsCompass = showsCompass
-    self.showsScale = showsScale
-    self.annotations = annotations
-    self.annotationViewFactory = annotationViewFactory
-    self.overlays = overlays
-    self.overlayRendererFactory = overlayRendererFactory
-    self.tapOrClickHandler = nil
-    self.longPressHandler = nil
-    self.annotationDragHandler = annotationDragHandler
-    self.regionChangingHandler = regionChangingHandler
-  }
-  public init(
-    configuration: Configuration? = nil,
-    mapRect: Binding<MKMapRect?>,
-    userTrackingMode: Binding<MKUserTrackingMode> = .constant(MKUserTrackingMode.none),
-    edgeInsets: XEdgeInsets = .init(),
-    showsUserLocation: Bool = false,
-    isZoomEnabled: Bool = true,
-    isScrollEnabled: Bool = true,
-    isRotateEnabled: Bool = true,
-    isPitchEnabled: Bool = true,
-    showsCompass: Bool = false,
-    showsScale: Bool = false,
-    annotations: [MKAnnotation] = [],
-    annotationViewFactory: AnnotationViewFactory = .empty,
-    overlays: [MKOverlay] = [],
-    overlayRendererFactory: OverlayRendererFactory = .empty,
-    tapOrClickHandler: @escaping DidTapOrClickMapHandler = { _ in },
-    longPressHandler: @escaping LongPressMapHandler = { _ in },
-    annotationDragHandler: @escaping AnnotationDragHandler = { _, _, _, _ in },
-    regionChangingHandler: @escaping RegionChangingHandler = { _, _ in }
-  ) {
-    self.configuration = configuration
-    self._visibleMapRect = mapRect
-    self._userTrackingMode = userTrackingMode
-    self.edgeInsets = edgeInsets
-    self.showsUserLocation = showsUserLocation
-    self.isZoomEnabled = isZoomEnabled
-    self.isScrollEnabled = isScrollEnabled
-    self.isRotateEnabled = isRotateEnabled
-    self.isPitchEnabled = isPitchEnabled
-    self.showsCompass = showsCompass
-    self.showsScale = showsScale
-    self.annotations = annotations
-    self.annotationViewFactory = annotationViewFactory
-    self.overlays = overlays
-    self.overlayRendererFactory = overlayRendererFactory
-    self.tapOrClickHandler = tapOrClickHandler
-    self.longPressHandler = longPressHandler
-    self.annotationDragHandler = annotationDragHandler
-    self.regionChangingHandler = regionChangingHandler
-  }
-#elseif os(macOS)
-  public init(
-    configuration: Configuration? = nil,
-    mapRect: Binding<MKMapRect?>,
-    userTrackingMode: Binding<MKUserTrackingMode> = .constant(MKUserTrackingMode.none),
-    edgeInsets: XEdgeInsets = .init(),
-    showsUserLocation: Bool = false,
-    isZoomEnabled: Bool = true,
-    isScrollEnabled: Bool = true,
-    isRotateEnabled: Bool = true,
-    isPitchEnabled: Bool = true,
-    showsPitchControl: Bool = false,
-    showsZoomControls: Bool = false,
-    showsCompass: Bool = false,
-    showsScale: Bool = false,
-    annotations: [MKAnnotation] = [],
-    annotationViewFactory: AnnotationViewFactory = .empty,
-    overlays: [MKOverlay] = [],
-    overlayRendererFactory: OverlayRendererFactory = .empty,
-    annotationDragHandler: @escaping AnnotationDragHandler = { _, _, _, _ in },
-    regionChangingHandler: @escaping RegionChangingHandler = { _, _ in }
-  ) {
-    self.configuration = configuration
-    self._visibleMapRect = mapRect
-    self._userTrackingMode = userTrackingMode
-    self.edgeInsets = edgeInsets
-    self.showsUserLocation = showsUserLocation
-    self.isZoomEnabled = isZoomEnabled
-    self.isScrollEnabled = isScrollEnabled
-    self.isRotateEnabled = isRotateEnabled
-    self.isPitchEnabled = isPitchEnabled
-    self.showsPitchControl = showsPitchControl
-    self.showsZoomControls = showsZoomControls
-    self.showsCompass = showsCompass
-    self.showsScale = showsScale
-    self.annotations = annotations
-    self.annotationViewFactory = annotationViewFactory
-    self.overlays = overlays
-    self.overlayRendererFactory = overlayRendererFactory
-    self.tapOrClickHandler = nil
-    self.longPressHandler = nil
-    self.annotationDragHandler = annotationDragHandler
-    self.regionChangingHandler = regionChangingHandler
-  }
-  public init(
-    configuration: Configuration? = nil,
-    mapRect: Binding<MKMapRect?>,
-    userTrackingMode: Binding<MKUserTrackingMode> = .constant(MKUserTrackingMode.none),
-    edgeInsets: XEdgeInsets = .init(),
-    showsUserLocation: Bool = false,
-    isZoomEnabled: Bool = true,
-    isScrollEnabled: Bool = true,
-    isRotateEnabled: Bool = true,
-    isPitchEnabled: Bool = true,
-    showsPitchControl: Bool = false,
-    showsZoomControls: Bool = false,
-    showsCompass: Bool = false,
-    showsScale: Bool = false,
-    annotations: [MKAnnotation] = [],
-    annotationViewFactory: AnnotationViewFactory = .empty,
-    overlays: [MKOverlay] = [],
-    overlayRendererFactory: OverlayRendererFactory = .empty,
-    tapOrClickHandler: @escaping DidTapOrClickMapHandler = { _ in },
-    longPressHandler: @escaping LongPressMapHandler = { _ in },
-    annotationDragHandler: @escaping AnnotationDragHandler = { _, _, _, _ in },
-    regionChangingHandler: @escaping RegionChangingHandler = { _, _ in }
-  ) {
-    self.configuration = configuration
-    self._visibleMapRect = mapRect
-    self._userTrackingMode = userTrackingMode
-    self.edgeInsets = edgeInsets
-    self.showsUserLocation = showsUserLocation
-    self.isZoomEnabled = isZoomEnabled
-    self.isScrollEnabled = isScrollEnabled
-    self.isRotateEnabled = isRotateEnabled
-    self.isPitchEnabled = isPitchEnabled
-    self.showsPitchControl = showsPitchControl
-    self.showsZoomControls = showsZoomControls
-    self.showsCompass = showsCompass
-    self.showsScale = showsScale
-    self.annotations = annotations
-    self.annotationViewFactory = annotationViewFactory
-    self.overlays = overlays
-    self.overlayRendererFactory = overlayRendererFactory
-    self.tapOrClickHandler = tapOrClickHandler
-    self.longPressHandler = longPressHandler
-    self.annotationDragHandler = annotationDragHandler
-    self.regionChangingHandler = regionChangingHandler
-  }
-#elseif os(tvOS)
-  public init(
-    configuration: Configuration? = nil,
-    mapRect: Binding<MKMapRect?>,
-    edgeInsets: XEdgeInsets = .init(),
-    showsUserLocation: Bool = false,
-    isZoomEnabled: Bool = true,
-    isScrollEnabled: Bool = true,
-    isRotateEnabled: Bool = true,
-    isPitchEnabled: Bool = true,
-    showsPitchControl: Bool = false,
-    showsZoomControls: Bool = false,
-    showsCompass: Bool = false,
-    showsScale: Bool = false,
-    annotations: [MKAnnotation] = [],
-    annotationViewFactory: AnnotationViewFactory = .empty,
-    overlays: [MKOverlay] = [],
-    overlayRendererFactory: OverlayRendererFactory = .empty,
-    regionChangingHandler: @escaping RegionChangingHandler = { _, _ in }
-  ) {
-    self.configuration = configuration
-    self._visibleMapRect = mapRect
-    self.edgeInsets = edgeInsets
-    self.showsUserLocation = showsUserLocation
-    self.isZoomEnabled = isZoomEnabled
-    self.isScrollEnabled = isScrollEnabled
-    self.isRotateEnabled = isRotateEnabled
-    self.isPitchEnabled = isPitchEnabled
-    self.showsCompass = showsCompass
-    self.showsScale = showsScale
-    self.annotations = annotations
-    self.annotationViewFactory = annotationViewFactory
-    self.overlays = overlays
-    self.tapOrClickHandler = nil
-    self.overlayRendererFactory = overlayRendererFactory
-    self.regionChangingHandler = regionChangingHandler
-  }
-  public init(
-    configuration: Configuration? = nil,
-    mapRect: Binding<MKMapRect?>,
-    edgeInsets: XEdgeInsets = .init(),
-    showsUserLocation: Bool = false,
-    isZoomEnabled: Bool = true,
-    isScrollEnabled: Bool = true,
-    isRotateEnabled: Bool = true,
-    isPitchEnabled: Bool = true,
-    showsPitchControl: Bool = false,
-    showsZoomControls: Bool = false,
-    showsCompass: Bool = false,
-    showsScale: Bool = false,
-    annotations: [MKAnnotation] = [],
-    annotationViewFactory: AnnotationViewFactory = .empty,
-    overlays: [MKOverlay] = [],
-    overlayRendererFactory: OverlayRendererFactory = .empty,
-    tapOrClickHandler: @escaping DidTapOrClickMapHandler = { _ in },
-    regionChangingHandler: @escaping RegionChangingHandler = { _, _ in }
-  ) {
-    self.configuration = configuration
-    self._visibleMapRect = mapRect
-    self.edgeInsets = edgeInsets
-    self.showsUserLocation = showsUserLocation
-    self.isZoomEnabled = isZoomEnabled
-    self.isScrollEnabled = isScrollEnabled
-    self.isRotateEnabled = isRotateEnabled
-    self.isPitchEnabled = isPitchEnabled
-    self.showsCompass = showsCompass
-    self.showsScale = showsScale
-    self.annotations = annotations
-    self.annotationViewFactory = annotationViewFactory
-    self.overlays = overlays
-    self.overlayRendererFactory = overlayRendererFactory
-    self.tapOrClickHandler = tapOrClickHandler
-    self.regionChangingHandler = regionChangingHandler
-  }
-#endif
+  @Environment(\.mapRegionChangingHandler) var regionChangingHandler
 }

--- a/Sources/AdvancedMap/AdvancedMapModifiers.swift
+++ b/Sources/AdvancedMap/AdvancedMapModifiers.swift
@@ -1,0 +1,286 @@
+import MapKit
+import SwiftUI
+
+struct ConfigurationKey: EnvironmentKey {
+  static let defaultValue: Configuration? = nil
+}
+
+struct EdgeInsetsKey: EnvironmentKey {
+  static let defaultValue: XEdgeInsets = .init()
+}
+
+struct ShowsUserLocationKey: EnvironmentKey {
+  static let defaultValue: Bool = false
+}
+
+struct IsZoomEnabledKey: EnvironmentKey {
+  static let defaultValue: Bool = true
+}
+
+struct IsScrollEnabledKey: EnvironmentKey {
+  static let defaultValue: Bool = true
+}
+
+struct IsRotationEnabledKey: EnvironmentKey {
+  static let defaultValue: Bool = true
+}
+
+struct IsPitchEnabledKey: EnvironmentKey {
+  static let defaultValue: Bool = true
+}
+
+struct ShowsPitchControlKey: EnvironmentKey {
+  static let defaultValue: Bool = false
+}
+
+struct ShowsZoomControlsKey: EnvironmentKey {
+  static let defaultValue: Bool = false
+}
+
+struct ShowsCompassKey: EnvironmentKey {
+  static let defaultValue: Bool = false
+}
+
+struct ShowsScaleKey: EnvironmentKey {
+  static let defaultValue: Bool = false
+}
+
+struct MapAnnotationsKey: EnvironmentKey {
+  static let defaultValue: [MKAnnotation] = []
+}
+
+struct MapAnnotationViewFactoryKey: EnvironmentKey {
+  static let defaultValue: AnnotationViewFactory? = nil
+}
+
+struct MapOverlaysKey: EnvironmentKey {
+  static let defaultValue: [MKOverlay] = []
+}
+
+struct MapOverlayRendererFactoryKey: EnvironmentKey {
+  static let defaultValue: OverlayRendererFactory? = nil
+}
+
+struct OnTapOrClickMapGestureKey: EnvironmentKey {
+  static let defaultValue: AdvancedMap.DidTapOrClickMapHandler? = nil
+}
+
+struct OnLongPressMapGestureKey: EnvironmentKey {
+  static let defaultValue: AdvancedMap.LongPressMapHandler? = nil
+}
+
+struct OnAnnotationDragGestureKey: EnvironmentKey {
+  static let defaultValue: AdvancedMap.AnnotationDragHandler? = nil
+}
+
+struct OnMapRegionChangingHandlerKey: EnvironmentKey {
+  static let defaultValue: AdvancedMap.RegionChangingHandler? = nil
+}
+
+extension EnvironmentValues {
+  var mapConfiguration: Configuration? {
+    get { self[ConfigurationKey.self] }
+    set { self[ConfigurationKey.self] = newValue }
+  }
+
+  var edgeInsets: XEdgeInsets {
+    get { self[EdgeInsetsKey.self] }
+    set { self[EdgeInsetsKey.self] = newValue }
+  }
+  var showsUserLocation: Bool {
+    get { self[ShowsUserLocationKey.self] }
+    set { self[ShowsUserLocationKey.self] = newValue }
+  }
+
+  var isZoomEnabled: Bool {
+    get { self[IsZoomEnabledKey.self] }
+    set { self[IsZoomEnabledKey.self] = newValue }
+  }
+
+  var isScrollEnabled: Bool {
+    get { self[IsScrollEnabledKey.self] }
+    set { self[IsScrollEnabledKey.self] = newValue }
+  }
+
+  var isRotationEnabled: Bool {
+    get { self[IsRotationEnabledKey.self] }
+    set { self[IsRotationEnabledKey.self] = newValue }
+  }
+
+  var isPitchEnabled: Bool {
+    get { self[IsPitchEnabledKey.self] }
+    set { self[IsPitchEnabledKey.self] = newValue }
+  }
+
+  var showsPitchControl: Bool {
+    get { self[ShowsPitchControlKey.self] }
+    set { self[ShowsPitchControlKey.self] = newValue }
+  }
+
+  var showsZoomControls: Bool {
+    get { self[ShowsZoomControlsKey.self] }
+    set { self[ShowsZoomControlsKey.self] = newValue }
+  }
+
+  var showsCompass: Bool {
+    get { self[ShowsCompassKey.self] }
+    set { self[ShowsCompassKey.self] = newValue }
+  }
+
+  var showsScale: Bool {
+    get { self[ShowsScaleKey.self] }
+    set { self[ShowsScaleKey.self] = newValue }
+  }
+
+  var mapAnnotations: [MKAnnotation] {
+    get { self[MapAnnotationsKey.self] }
+    set { self[MapAnnotationsKey.self] = newValue }
+  }
+
+  var annotationViewFactory: AnnotationViewFactory? {
+    get { self[MapAnnotationViewFactoryKey.self] }
+    set { self[MapAnnotationViewFactoryKey.self] = newValue }
+  }
+
+  var mapOverlays: [MKOverlay] {
+    get { self[MapOverlaysKey.self] }
+    set { self[MapOverlaysKey.self] = newValue }
+  }
+
+  var overlayRendererFactory: OverlayRendererFactory? {
+    get { self[MapOverlayRendererFactoryKey.self] }
+    set { self[MapOverlayRendererFactoryKey.self] = newValue }
+  }
+
+  var onTapOrClickGesture: AdvancedMap.DidTapOrClickMapHandler? {
+    get { self[OnTapOrClickMapGestureKey.self] }
+    set { self[OnTapOrClickMapGestureKey.self] = newValue }
+  }
+
+  var onLongPressMapGesture: AdvancedMap.LongPressMapHandler? {
+    get { self[OnLongPressMapGestureKey.self] }
+    set { self[OnLongPressMapGestureKey.self] = newValue }
+  }
+
+  var onAnnotationDragGesture: AdvancedMap.AnnotationDragHandler? {
+    get { self[OnAnnotationDragGestureKey.self] }
+    set { self[OnAnnotationDragGestureKey.self] = newValue }
+  }
+
+  var mapRegionChangingHandler: AdvancedMap.RegionChangingHandler? {
+    get { self[OnMapRegionChangingHandlerKey.self] }
+    set { self[OnMapRegionChangingHandlerKey.self] = newValue }
+  }
+}
+
+extension View {
+  public func mapConfiguration(_ configuration: Configuration) -> some View {
+    environment(\.mapConfiguration, configuration)
+  }
+
+  public func mapEdgeInsets(_ edgeInsets: XEdgeInsets) -> some View {
+    environment(\.edgeInsets, edgeInsets)
+  }
+
+  public func showsUserLocation(_ showsUserLocation: Bool) -> some View {
+    environment(\.showsUserLocation, showsUserLocation)
+  }
+
+  public func isZoomEnabled(_ isZoomEnabled: Bool) -> some View {
+    environment(\.isZoomEnabled, isZoomEnabled)
+  }
+
+  public func isScrollEnabled(_ isScrollEnabled: Bool) -> some View {
+    environment(\.isScrollEnabled, isScrollEnabled)
+  }
+
+  public func isRotationEnabled(_ isRotationEnabled: Bool) -> some View {
+    environment(\.isRotationEnabled, isRotationEnabled)
+  }
+
+  public func isPitchEnabled(_ isPitchEnabled: Bool) -> some View {
+    environment(\.isPitchEnabled, isPitchEnabled)
+  }
+
+#if os(macOS)
+  public func showsPitchControl(_ showsPitchControl: Bool) -> some View {
+    environment(\.showsPitchControl, showsPitchControl)
+  }
+
+  public func showsZoomControls(_ showsZoomControls: Bool) -> some View {
+    environment(\.showsZoomControls, showsZoomControls)
+  }
+#endif
+
+  public func showsCompass(_ showsCompass: Bool) -> some View {
+    environment(\.showsCompass, showsCompass)
+  }
+
+  public func showsScale(_ showsScale: Bool) -> some View {
+    environment(\.showsScale, showsScale)
+  }
+
+  public func annotations(
+    _ annotations: [MKAnnotation],
+    annotationViewFactory: AnnotationViewFactory
+  ) -> some View {
+    environment(\.mapAnnotations, annotations)
+      .environment(\.annotationViewFactory, annotationViewFactory)
+  }
+
+  public func overlays(
+    _ overlays: [MKOverlay],
+    overlayRendererFactory: OverlayRendererFactory
+  ) -> some View {
+    environment(\.mapOverlays, overlays)
+      .environment(\.overlayRendererFactory, overlayRendererFactory)
+  }
+
+  #if os(iOS)
+
+  public func onTapMapGesture(
+    _ tapOrClickHandler: @escaping AdvancedMap.DidTapOrClickMapHandler
+  ) -> some View {
+    environment(\.onTapOrClickGesture, tapOrClickHandler)
+  }
+
+  #elseif os(macOS)
+
+  public func onClickMapGesture(
+    _ tapOrClickHandler: @escaping AdvancedMap.DidTapOrClickMapHandler
+  ) -> some View {
+    environment(\.onTapOrClickGesture, tapOrClickHandler)
+  }
+
+  #endif
+
+  #if os(iOS) || os(macOS)
+  public func onTapOrClickMapGesture(
+    _ tapOrClickHandler: @escaping AdvancedMap.DidTapOrClickMapHandler
+  ) -> some View {
+    environment(\.onTapOrClickGesture, tapOrClickHandler)
+  }
+  #endif
+
+  public func onLongPressMapGesture(
+    _ longPressHandler: @escaping AdvancedMap.LongPressMapHandler
+  ) -> some View {
+    environment(\.onLongPressMapGesture, longPressHandler)
+  }
+
+#if os(iOS) || os(macOS)
+
+  public func annotationDragHandler(
+    _ annotationDragHandler: @escaping AdvancedMap.AnnotationDragHandler
+  ) -> some View {
+    environment(\.onAnnotationDragGesture, annotationDragHandler)
+  }
+
+#endif
+
+  public func mapRegionChangingHandler(
+    _ regionChangingHandler: @escaping AdvancedMap.RegionChangingHandler
+  ) -> some View {
+    environment(\.mapRegionChangingHandler, regionChangingHandler)
+  }
+}

--- a/Sources/AdvancedMap/MapViewCoordinator.swift
+++ b/Sources/AdvancedMap/MapViewCoordinator.swift
@@ -35,12 +35,12 @@ public class Coordinator: NSObject, MKMapViewDelegate {
 
   public func mapView(_ mapView: MKMapView, regionWillChangeAnimated animated: Bool) {
     isChangingRegion = true
-    advancedMap.regionChangingHandler(true, animated)
+    advancedMap.regionChangingHandler?(true, animated)
   }
 
   public func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
     isChangingRegion = false
-    advancedMap.regionChangingHandler(false, animated)
+    advancedMap.regionChangingHandler?(false, animated)
     
     if isFirstRender {
       DispatchQueue.main.async { [weak self] in
@@ -60,11 +60,11 @@ public class Coordinator: NSObject, MKMapViewDelegate {
   #endif
 
   public func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
-    advancedMap.annotationViewFactory.mapView(mapView, viewFor: annotation)
+    advancedMap.annotationViewFactory?.mapView(mapView, viewFor: annotation)
   }
 
   public func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
-    advancedMap.overlayRendererFactory.rendererFor(overlay) ?? .init()
+    advancedMap.overlayRendererFactory?.rendererFor(overlay) ?? .init()
   }
 
   #if os(iOS) || os(macOS)
@@ -75,7 +75,7 @@ public class Coordinator: NSObject, MKMapViewDelegate {
       fromOldState oldState: MKAnnotationView.DragState
   ) {
     guard let annotation = view.annotation else { return }
-    advancedMap.annotationDragHandler(annotation, annotation.coordinate, oldState, newState)
+    advancedMap.annotationDragHandler?(annotation, annotation.coordinate, oldState, newState)
   }
   #endif
 


### PR DESCRIPTION
[Problem]
* The initializer API was the only way to pass parameters to the map and was getting very large. Didn't feel very much like a SwiftUI native interface.

[Solution]
* Move most features to being passed in via the environment. Delete the initializer based injection.